### PR TITLE
format Exception to display full details

### DIFF
--- a/Echo.ProcessJS/scripts/process.js
+++ b/Echo.ProcessJS/scripts/process.js
@@ -671,7 +671,7 @@ var Process = (function () {
                 function () { return "" }) +
             "</div>" +
             match(msg.Exception,
-                function (value) { return "<div class='process-log-row testbed-log-rowError'><div id='log-ex-msg'>" + value + "</div></div>"; },
+                function (value) { return "<div class='process-log-row testbed-log-rowError'><div id='log-ex-msg'>" + JSON.stringify(value, null, 4) + "</div></div>"; },
                 function () { return "" }) +
             "</div>";
     };


### PR DESCRIPTION
Currently the Exception is rendered as [Object] which is not very useful. I have put JSON.stringify so we can see full details (type, message, stracktrace).