### PR TITLE
incorrect unit value

### DIFF
--- a/Echo.ProcessJS/scripts/process.js
+++ b/Echo.ProcessJS/scripts/process.js
@@ -3,7 +3,7 @@
 // Copyright (c) 2014-2017 Paul Louth
 // https://github.com/louthy/language-ext/blob/master/LICENSE.md
 
-var unit = "(unit)";
+var unit = {};
 
 if (!window.location.origin) {
     window.location.origin = window.location.protocol + "//"


### PR DESCRIPTION
I tested it with a process like this: 
    spawn<Unit>("path", _ => {}); 

JS call like this:
    Process.tell('/root/user/path', unit);