### PR TITLE
adds Lazy parameter to spawn (allow spawning not-yet-started actors available)

### DIFF
--- a/Echo.Process/Prelude.cs
+++ b/Echo.Process/Prelude.cs
@@ -230,6 +230,13 @@ namespace Echo
             ActorContext.System(pid).Kill(pid, false);
 
         /// <summary>
+        /// Send StartupProcess message to a process that isn't running (e.g. spawned with Lazy = true)
+        /// </summary>
+        public static Unit startup(ProcessId pid) =>
+            ActorContext.System(pid).TellSystem(pid, SystemMessage.StartupProcess);
+
+
+        /// <summary>
         /// Shutdown a specified running process.
         /// Forces the specified Process to shutdown.  The shutdown message jumps 
         /// ahead of any messages already in the process's queue.  Any Process

--- a/Echo.Process/Prelude_Spawn.cs
+++ b/Echo.Process/Prelude_Spawn.cs
@@ -100,6 +100,7 @@ namespace Echo
         /// <param name="Strategy">Failure supervision strategy</param>
         /// <param name="Terminated">Message function to call when a Process [that this Process
         /// watches] terminates</param>
+        /// <param name="Lazy">If set to true actor will not start automatically, you need to tellSystem(processId, SystemMessage.StartupProcess) manually</param>
         /// <returns>A ProcessId that identifies the child</returns>
         public static ProcessId spawn<S, T>(
             ProcessName Name,
@@ -109,7 +110,8 @@ namespace Echo
             State<StrategyContext, Unit> Strategy = null,
             int MaxMailboxSize = ProcessSetting.DefaultMailboxSize,
             Func<S, ProcessId, S> Terminated = null,
-            SystemName System = default(SystemName)
+            SystemName System = default(SystemName),
+            bool Lazy = false
             )
         {
             if (System.IsValid && ActorContext.Request != null) throw new ProcessException("When spawning you can only specify a System from outside of a Process", ActorContext.Self[Name].Path, "");
@@ -122,7 +124,7 @@ namespace Echo
                 ? sys.UserContext.Self
                 : ActorContext.SelfProcess;
 
-            return sys.ActorCreate(parent, Name, Inbox, Setup, Terminated, Strategy, Flags, MaxMailboxSize, false);
+            return sys.ActorCreate(parent, Name, Inbox, Setup, Terminated, Strategy, Flags, MaxMailboxSize, Lazy);
         }
 
         /// <summary>


### PR DESCRIPTION
This is a suggestion to allow users (me) to spawn processes that can be started later.

This avoids building same mechanism in user space that is already supported internally in echo: call setup function (and activate actor) later.

This especially allows to spawn an inactive actor, observing it (observe/subscribe) and be sure to activate it not before subscribtion could be successful. This solves the problem when the publishing actor starts producing messages directly after setup function is called and might subscribe too late.