### PR TITLE
Fix actor strategy handling

### DIFF
--- a/Echo.Process/ActorSys/ActorInboxCommon.cs
+++ b/Echo.Process/ActorSys/ActorInboxCommon.cs
@@ -54,7 +54,7 @@ namespace Echo
 
                     case Message.TagSpec.Pause:
                         inbox.Pause();
-                        return InboxDirective.Pause;
+                        break; // do not return InboxDirective.Pause because system queue should never pause
 
                     case Message.TagSpec.Watch:
                         var awm = msg as SystemAddWatcherMessage;

--- a/Echo.Process/ActorSys/PausableBlockingQueue.cs
+++ b/Echo.Process/ActorSys/PausableBlockingQueue.cs
@@ -10,7 +10,7 @@ namespace Echo.ActorSys
 {
     public class PausableBlockingQueue<A> : IDisposable
     {
-        readonly EventWaitHandle pauseWait = new AutoResetEvent(true);
+        readonly EventWaitHandle pauseWait = new AutoResetEvent(false);
         readonly BlockingCollection<A> items;
         readonly CancellationTokenSource tokenSource;
         readonly CancellationToken token;

--- a/Echo.Process/Strategy/MessageDirective.cs
+++ b/Echo.Process/Strategy/MessageDirective.cs
@@ -61,8 +61,8 @@ namespace Echo
             new ForwardToProcess(pid);
 
         /// <summary>
-        /// Forward the failed message back to the Process that failed.
-        /// It will join the back of the queue.
+        /// Message remains at the front of the queue for when the process has recovered.
+        /// Could cause blocking for permanent failures.
         /// </summary>
         public static MessageDirective StayInQueue =>
             new StayInQueue();


### PR DESCRIPTION
Compare my issue #37.

This should fix two bugs with retries (Strategy).

The change in ActorInboxCommon was made so *system* message queue does not get Paused (which caused the Unpause message to never get processed).

The changed default in PausableBlockingQueue is necessary to avoid first inbox Pause to be ignored.

