### PR TITLE
hopefully fixes RunStrategy for Restart (unpause AFTER restart)

### DIFF
--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -926,18 +926,17 @@ namespace Echo
                 }
             }
 
-            unpause(pid);
-
             switch (directive.Type)
             {
                 case DirectiveType.Escalate:
                     tellSystem(Parent.Actor.Id, SystemMessage.ChildFaulted(pid, sender, e, message), Self);
                     break;
                 case DirectiveType.Resume:
-                    // Do nothing
+                    unpause(pid);
                     break;
                 case DirectiveType.Restart:
                     Restart();
+                    unpause(pid);
                     break;
                 case DirectiveType.Stop:
                     ShutdownProcess(false);


### PR DESCRIPTION
I hope this is the correct fix to handle Restart (RunStrategy).

Now unpause is called after Restart.

**ATTENTION**: I'm not sure whether Escalate and/or Shutdown need unpause, too. (They had, now the don't have anymore.)

(compare #37)