### PR TITLE
fix subscribe / subscribeState: save (current) Self for async use in observable

### DIFF
--- a/Echo.Process/Prelude_PubSub.cs
+++ b/Echo.Process/Prelude_PubSub.cs
@@ -61,10 +61,13 @@ namespace Echo
         /// This should be used from within a process' message loop only
         /// </remarks>
         /// <returns>IDisposable, call IDispose to end the subscription</returns>
-        public static Unit subscribe(ProcessId pid) =>
-            InMessageLoop
-                ? ActorContext.Request.Self.Actor.AddSubscription(pid, ActorContext.System(pid).Observe<object>(pid).Subscribe(x => tell(Self, x, pid)))
+        public static Unit subscribe(ProcessId pid)
+        {
+            var savedSelf = Self;
+            return InMessageLoop
+                ? ActorContext.Request.Self.Actor.AddSubscription(pid, ActorContext.System(pid).Observe<object>(pid).Subscribe(x => tell(savedSelf, x, pid)))
                 : raiseUseInMsgLoopOnlyException<Unit>(nameof(subscribe));
+        }
 
         /// <summary>
         /// Unsubscribe from a process's publications
@@ -199,11 +202,14 @@ namespace Echo
         /// This should be used from within a process' message loop only
         /// </remarks>
         /// <returns>IObservable T</returns>
-        public static Unit subscribeState<T>(ProcessId pid) =>
-            InMessageLoop
+        public static Unit subscribeState<T>(ProcessId pid)
+        {
+            var savedSelf = Self;
+            return InMessageLoop
                 ? ActorContext.Request.Self.Actor.AddSubscription(
-                      pid,
-                      ActorContext.System(pid).ObserveState<T>(pid).Subscribe(x => tell(Self, x, pid)))
+                    pid,
+                    ActorContext.System(pid).ObserveState<T>(pid).Subscribe(x => tell(savedSelf, x, pid)))
                 : raiseUseInMsgLoopOnlyException<Unit>(nameof(subscribeState));
+        }
     }
 }


### PR DESCRIPTION
Note: I didn't test this, but IMHO this fix is necessary to make subscribe work because `Self` would be arbitrary due to async call (observable). 

Related to #40 -- but this PR does not include some free observe/observeUnsafe requested in #40.