### PR TITLE
adds feature CancellationToken in message loop

### DIFF
--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -75,6 +75,11 @@ namespace Echo
         {
             lock(sync)
             {
+                if (cancellationTokenSource.IsCancellationRequested)
+                {
+                    return unit;
+                }
+
                 if (state.IsSome) return unit;
 
                 var savedReq = ActorContext.Request.CurrentRequest;

--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -722,6 +722,8 @@ namespace Echo
         {
             lock (sync)
             {
+                if (cancellationTokenSource.IsCancellationRequested) return InboxDirective.PushToFrontOfQueue;
+
                 var savedReq = ActorContext.Request.CurrentRequest;
                 var savedFlags = ActorContext.Request.ProcessFlags;
                 var savedMsg = ActorContext.Request.CurrentMsg;

--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -722,7 +722,7 @@ namespace Echo
         {
             lock (sync)
             {
-                if (cancellationTokenSource.IsCancellationRequested) return InboxDirective.PushToFrontOfQueue;
+                if (cancellationTokenSource.IsCancellationRequested) return InboxDirective.Shutdown;
 
                 var savedReq = ActorContext.Request.CurrentRequest;
                 var savedFlags = ActorContext.Request.ProcessFlags;

--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -25,6 +25,7 @@ namespace Echo
         readonly ProcessFlags flags;
         readonly Subject<object> publishSubject = new Subject<object>();
         readonly Subject<object> stateSubject = new Subject<object>();
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         readonly Option<ICluster> cluster;
         Map<string, IDisposable> subs = Map<string, IDisposable>();
         Map<string, ActorItem> children = Map<string, ActorItem>();
@@ -324,6 +325,8 @@ namespace Echo
         public Map<string, ActorItem> Children =>
             children;
 
+        public CancellationTokenSource CancellationTokenSource => cancellationTokenSource;
+
         /// <summary>
         /// Clears the state (keeps the mailbox items)
         /// </summary>
@@ -397,6 +400,7 @@ namespace Echo
         /// </summary>
         public Unit Shutdown(bool maintainState)
         {
+            cancellationTokenSource.Cancel();
             lock(sync)
             {
                 if (maintainState == false && Flags != ProcessFlags.Default)
@@ -952,6 +956,7 @@ namespace Echo
 
         public Unit ShutdownProcess(bool maintainState)
         {
+            cancellationTokenSource.Cancel();
             lock (sync)
             {
                 return Parent.Actor.Children.Find(Name.Value).IfSome(self =>
@@ -985,6 +990,7 @@ namespace Echo
         {
             RemoveAllSubscriptions();
             DisposeState();
+            cancellationTokenSource.Dispose();
         }
 
         void DisposeState()

--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -405,7 +405,7 @@ namespace Echo
         /// </summary>
         public Unit Shutdown(bool maintainState)
         {
-            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Cancel(); // this will signal other operations not to start processing more messages (ProcessMessage) or startup again (Startup), even if they already received something from the queue
             lock(sync)
             {
                 if (maintainState == false && Flags != ProcessFlags.Default)

--- a/Echo.Process/ActorSys/IActor.cs
+++ b/Echo.Process/ActorSys/IActor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Echo
@@ -93,6 +94,8 @@ namespace Echo
         /// State stream - sent after each message loop
         /// </summary>
         IObservable<object> StateStream { get; }
+
+        CancellationTokenSource CancellationTokenSource { get; }
 
         InboxDirective ProcessMessage(object message);
         InboxDirective ProcessAsk(ActorRequest request);

--- a/Echo.Process/ActorSys/NullProcess.cs
+++ b/Echo.Process/ActorSys/NullProcess.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using static LanguageExt.Prelude;
@@ -37,6 +38,9 @@ namespace Echo
         public Unit Publish(object message) => unit;
         public IObservable<object> PublishStream => null;
         public IObservable<object> StateStream => null;
+
+        public CancellationTokenSource CancellationTokenSource => new CancellationTokenSource();
+
         public InboxDirective ProcessTerminated(ProcessId pid) => InboxDirective.Default;
         public InboxDirective ProcessMessage(object message) => InboxDirective.Default;
         public InboxDirective ProcessAsk(ActorRequest request) => InboxDirective.Default;

--- a/Echo.Process/Prelude.cs
+++ b/Echo.Process/Prelude.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 using System.Threading.Tasks;
 using static LanguageExt.Prelude;
 
@@ -188,6 +189,19 @@ namespace Echo
                                   .Map( kv => kv.Value )
                                   .Head()
                 : raiseUseInMsgLoopOnlyException<ProcessId>(nameof(child));
+
+        /// <summary>
+        /// Gets a CancellationToken that is in state Cancel when actor will shutdown.
+        /// This can be used in message loop to e.g. avoid long running message loop blocking actor shutdown.
+        /// </summary>
+        /// <remarks>
+        /// This should be used from within a process' message loop only
+        /// </remarks>
+        public static CancellationToken SelfProcessCancellationToken =>
+            InMessageLoop 
+                ? ActorContext.SelfProcess.Actor.CancellationTokenSource.Token
+                : raiseUseInMsgLoopOnlyException<CancellationToken>(nameof(SelfProcessCancellationToken));
+
 
         /// <summary>
         /// Immediately kills the Process that is running from within its message

--- a/Echo.Tests/IssuesTests.cs
+++ b/Echo.Tests/IssuesTests.cs
@@ -10,7 +10,7 @@ namespace Echo.Tests
 {
     public class IssuesTests
     {
-
+        [Collection("Initialise")]
         public class Issue31
         {
             public class AskFixture : IDisposable

--- a/Echo.Tests/LifeTimeTests.cs
+++ b/Echo.Tests/LifeTimeTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using LanguageExt;
+using static LanguageExt.Prelude;
+using static Echo.Process;
+using static Echo.ProcessConfig;
+using static Echo.Strategy;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Echo.Tests
+{
+    public class LifeTimeTests
+    {
+        public class ProcessFixture : IDisposable
+        {
+            public ProcessFixture()
+            {
+                initialise();
+                subscribe<Exception>(Errors(), e => raise<Unit>(e));
+            }
+
+            public void Dispose() => shutdownAll();
+        }
+
+
+        public class LifeTimeIssues : IClassFixture<ProcessFixture>
+        {
+            private static void WaitForActor(ProcessId pid)
+            {
+                using (var mre = new ManualResetEvent(false))
+                {
+                    using (observeStateUnsafe<Unit>(pid).Subscribe(_ => { }, () => mre.Set()))
+                    {
+                        mre.WaitOne();
+                    }
+
+                    // actor is in shutdown, wait a very short time
+                    while (exists(pid))
+                    {
+                        Task.Delay(1).Wait();
+                    }
+                }
+            }
+
+            [Fact(Timeout = 5000)]
+            // make sure that the state is not re-initialized after kill
+            // issue 48 (race condition resulted in inboxFn called after DisposeState)
+            public void NoZombieState()
+            {
+                var events = new List<string>();
+                var actor = spawn<IDisposable, string>(nameof(NoZombieState),
+                    () =>
+                    {
+                        events.Add("setup");
+                        return Disposable.Create(
+                            () => events.Add("dispose")
+                        );
+                    },
+                    (state, msg) =>
+                    {
+                        events.Add(msg);
+                        Task.Delay(100 * milliseconds).Wait();
+                        Assert.Equal(1, Process.inboxCount(Self)); // msg inbox2 will arrive before kill is executed
+                        kill();
+                        return state;
+                    });
+                tell(actor, "inbox1"); // inbox1 might arrive before StartUp-System-Message (but doesn't matter)
+                tell(actor, "inbox2"); // msg inbox2 will arrive before kill is executed
+                WaitForActor(actor);
+                Assert.False(Process.exists(actor));
+                Assert.Equal(events.Freeze(), List("setup", "inbox1", "dispose"));
+            }
+
+
+            [Fact(Timeout = 5000)]
+            // issue 47 / pr 49
+            public void ActorWithoutCancellationToken()
+            {
+                int inboxResult = 0;
+
+                var actor = spawn(nameof(ActorWithoutCancellationToken), (string msg) =>
+                {
+                    Task.Delay(100 * milliseconds).Wait();
+                    inboxResult++;
+                });
+                tell(actor, "test");
+                kill(actor);
+                Assert.Equal(1, inboxResult);
+            }
+
+            [Fact(Timeout = 5000)]
+            // issue 47 / pr 49
+            public void ActorWithCancellationToken()
+            {
+                int inboxResult = 0;
+
+                var actor = spawn(nameof(ActorWithCancellationToken), (string msg) =>
+                {
+                    Task.Delay(100 * milliseconds).Wait(SelfProcessCancellationToken);
+                    if (!SelfProcessCancellationToken.IsCancellationRequested) inboxResult++;
+                });
+                tell(actor, "test");
+                kill(actor);
+                Assert.Equal(0, inboxResult);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Will allow reacting on kill/shutdown running.

Would solve my request #47.

In message look one can access SelfProcessCancellationToken (via Context) to get a cancellationToken for further use.
