### PR TITLE
changes system shutdown order: "user" actor first

### DIFF
--- a/Echo.Process/ActorSys/ActorSystem.cs
+++ b/Echo.Process/ActorSys/ActorSystem.cs
@@ -202,7 +202,9 @@ namespace Echo
                     }
                     try
                     {
-                        rootItem.Actor.Children.Iter(c => c.Actor.ShutdownProcess(true));
+                        rootItem.Actor.Children.Values
+                            .OrderByDescending(c => c.Actor.Id == User) // shutdown "user" first
+                            .Iter(c => c.Actor.ShutdownProcess(true));
                     }
                     catch(Exception e)
                     {


### PR DESCRIPTION
I had this small issue on shutdownAll: If an exception is thrown in a "user" actor during shutdown then this error caused an error entry on ProcessSystemLog saying "/root/system/errors" is missing -- because the "system" actor already was shut down.

This PR should fix this by shutting down "/root/user" first and everything else (including "/root/system") after that.
