### PR TITLE
Fix strategy restart unpause timing

### DIFF
--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -981,6 +981,7 @@ namespace Echo
                     break;
                 case DirectiveType.Restart:
                     Restart(unPauseAfterRestart);
+                    unpause(pid); // BUG: remove this line (PR #57)
                     break;
                 case DirectiveType.Stop:
                     ShutdownProcess(false);

--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -981,7 +981,6 @@ namespace Echo
                     break;
                 case DirectiveType.Restart:
                     Restart(unPauseAfterRestart);
-                    unpause(pid); // BUG: remove this line (PR #57)
                     break;
                 case DirectiveType.Stop:
                     ShutdownProcess(false);

--- a/Echo.Process/ActorSys/ActorSystem.cs
+++ b/Echo.Process/ActorSys/ActorSystem.cs
@@ -517,7 +517,7 @@ namespace Echo
                 inbox.Startup(actor, parent, cluster, maxMailboxSize);
                 if (!lazy)
                 {
-                    TellSystem(actor.Id, SystemMessage.StartupProcess);
+                    TellSystem(actor.Id, SystemMessage.StartupProcess(false));
                 }
             }
             catch

--- a/Echo.Process/ActorSys/IActor.cs
+++ b/Echo.Process/ActorSys/IActor.cs
@@ -44,12 +44,14 @@ namespace Echo
         /// <summary>
         /// Clears the state (keeps the mailbox items)
         /// </summary>
-        Unit Restart();
+        /// <param name="unpauseAfterRestart">if set to true then inbox shall be unpaused after starting up again</param>
+        Unit Restart(bool unpauseAfterRestart);
 
         /// <summary>
         /// Startup
         /// </summary>
-        Unit Startup();
+        /// <returns>returns InboxDirective.Pause if Startup will unpause inbox (via some strategy error handling). Otherwise InboxDirective.Default</returns>
+        InboxDirective Startup();
 
         /// <summary>
         /// Shutdown

--- a/Echo.Process/ActorSys/NullProcess.cs
+++ b/Echo.Process/ActorSys/NullProcess.cs
@@ -26,8 +26,8 @@ namespace Echo
         public ProcessName Name => "$";
         public ActorItem Parent => new ActorItem(new NullProcess(System), new NullInbox(), ProcessFlags.Default);
         public State<StrategyContext, Unit> Strategy => Process.DefaultStrategy;
-        public Unit Restart() => unit;
-        public Unit Startup() => unit;
+        public Unit Restart(bool unpauseAfterRestart) => unit;
+        public InboxDirective Startup() => InboxDirective.Default;
         public Unit Shutdown(bool maintainState) => unit;
         public Unit LinkChild(ActorItem item) => unit;
         public Unit UnlinkChild(ProcessId item) => unit;

--- a/Echo.Process/ActorSys/PausableBlockingQueue.cs
+++ b/Echo.Process/ActorSys/PausableBlockingQueue.cs
@@ -60,25 +60,19 @@ namespace Echo.ActorSys
                                 Process.logErr(e);
                             }
 
-                            switch (directive)
+                            if (directive.HasFlag(InboxDirective.Shutdown))
                             {
-                                case InboxDirective.Pause:
-                                    addToFrontOfQueue = false;
+                                addToFrontOfQueue = false;
+                                Cancel();
+                            }
+                            else
+                            {
+                                addToFrontOfQueue = directive.HasFlag(InboxDirective.PushToFrontOfQueue);
+
+                                if (directive.HasFlag(InboxDirective.Pause))
+                                {
                                     Pause();
-                                    break;
-
-                                case InboxDirective.Shutdown:
-                                    addToFrontOfQueue = false;
-                                    Cancel();
-                                    return;
-
-                                case InboxDirective.PushToFrontOfQueue:
-                                    addToFrontOfQueue = true;
-                                    break;
-
-                                case InboxDirective.Default:
-                                    addToFrontOfQueue = false;
-                                    break;
+                                }
                             }
                         }
                         while (addToFrontOfQueue);

--- a/Echo.Process/Messages/MessageSerialiser.cs
+++ b/Echo.Process/Messages/MessageSerialiser.cs
@@ -41,7 +41,7 @@ namespace Echo
                 case Message.TagSpec.UserTerminated:    return ((TerminatedMessage)DeserialiseMsgContent(msg)).SetSystem(sys);
 
                 case Message.TagSpec.GetChildren:       return UserControlMessage.GetChildren;
-                case Message.TagSpec.StartupProcess:    return SystemMessage.StartupProcess;
+                case Message.TagSpec.StartupProcess:    return (StartupProcessMessage)DeserialiseMsgContent(msg);
                 case Message.TagSpec.ShutdownProcess:   return (ShutdownProcessMessage)DeserialiseMsgContent(msg);
 
                 case Message.TagSpec.Restart:           return SystemMessage.Restart;

--- a/Echo.Process/Messages/SystemMessage.cs
+++ b/Echo.Process/Messages/SystemMessage.cs
@@ -14,7 +14,7 @@ namespace Echo
         public static SystemMessage UnlinkChild(ProcessId pid) => new SystemUnLinkChildMessage(pid);
         public static SystemMessage ChildFaulted(ProcessId pid, ProcessId sender, Exception ex, object msg) => new SystemChildFaultedMessage(pid, sender, ex, msg);
         public static SystemMessage ShutdownProcess(bool maintainState) => new ShutdownProcessMessage(maintainState);
-        public static SystemMessage StartupProcess => new StartupProcessMessage();
+        public static SystemMessage StartupProcess(bool unpauseAfterStartup) => new StartupProcessMessage(unpauseAfterStartup);
         public static SystemMessage Restart => new SystemRestartMessage();
         public static SystemMessage Pause => new SystemPauseMessage();
         public static SystemMessage Unpause => new SystemUnpauseMessage();
@@ -27,6 +27,15 @@ namespace Echo
     class StartupProcessMessage : SystemMessage
     {
         public override TagSpec Tag => TagSpec.StartupProcess;
+        public StartupProcessMessage(bool unpauseAfterStartup)
+        {
+            UnpauseAfterStartup = unpauseAfterStartup;
+        }
+
+        public readonly bool UnpauseAfterStartup;
+
+        public override string ToString() =>
+            $"StartupProcess({UnpauseAfterStartup})";
     }
 
     class SystemPauseMessage : SystemMessage

--- a/Echo.Process/Prelude.cs
+++ b/Echo.Process/Prelude.cs
@@ -247,7 +247,7 @@ namespace Echo
         /// Send StartupProcess message to a process that isn't running (e.g. spawned with Lazy = true)
         /// </summary>
         public static Unit startup(ProcessId pid) =>
-            ActorContext.System(pid).TellSystem(pid, SystemMessage.StartupProcess);
+            ActorContext.System(pid).TellSystem(pid, SystemMessage.StartupProcess(false));
 
         /// <summary>
         /// Shutdown a specified running process.

--- a/Echo.Process/Strategy/InboxDirective.cs
+++ b/Echo.Process/Strategy/InboxDirective.cs
@@ -8,6 +8,6 @@ namespace Echo
         Default = 0,
         PushToFrontOfQueue = 1,
         Pause = 2,
-        Shutdown = 3
+        Shutdown = 4
     }
 }

--- a/Echo.Tests/StrategyTests.cs
+++ b/Echo.Tests/StrategyTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using LanguageExt;
+using static LanguageExt.Prelude;
+using static Echo.Process;
+using static Echo.ProcessConfig;
+using static Echo.Strategy;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LanguageExt.UnitsOfMeasure;
+
+namespace Echo.Tests
+{
+    public class StrategyTests
+    {
+        public class ProcessFixture : IDisposable
+        {
+            public ProcessFixture()
+            {
+                initialise();
+                subscribe<Exception>(Errors(), e => raise<Unit>(e));
+            }
+
+            public void Dispose() => shutdownAll();
+        }
+
+
+        public class StrategyRestartDelayIssue : IClassFixture<ProcessFixture>
+        {
+            [Fact(Timeout = 10000)]
+            // issue #57 (Fix strategy restart unpause timing)
+            public static void DelayMissing()
+            {
+                var events = new List<(Time, string)>();
+                using (var mre = new ManualResetEvent(false))
+                {
+                    var begin = DateTimeOffset.MinValue;
+                    int setupCallCounter = 0;
+                    int inboxCallCounter = 0;
+                    var outer = spawn<Unit, string>(nameof(DelayMissing) + "-wrapper", () =>
+                    {
+                        spawn<Unit, string>(nameof(DelayMissing),
+                            () =>
+                            {
+
+                                setupCallCounter++;
+                                if (setupCallCounter == 1) begin = DateTimeOffset.Now; // set begin here to make timing more precise
+                                events.Add((DateTimeOffset.Now - begin, $"setup {setupCallCounter}"));
+                                // Console.WriteLine($"{DateTimeOffset.Now:O} setup {setupCallCounter}");
+                                if (setupCallCounter > 1) throw new Exception($"{DateTimeOffset.Now} setup {setupCallCounter} fails");
+                                SelfProcessCancellationToken.Register(() => mre.Set());
+                                return unit;
+                            },
+                            (state, msg) =>
+                            {
+                                inboxCallCounter++;
+                                events.Add((DateTimeOffset.Now - begin, $"inbox {inboxCallCounter}"));
+                                // Console.WriteLine($"{DateTimeOffset.Now:O} inbox {inboxCallCounter}");
+                                throw new Exception($"{DateTimeOffset.Now} inbox {inboxCallCounter} fails");
+                            });
+                        return unit;
+                    }, (state, msg) =>
+                    {
+                        reply(msg.ToUpper());
+                        return state;
+                    }, Strategy: from x in Context
+                    from y in x.Exception is ProcessSetupException 
+                        ? (x.Global.Failures < 5 ? Compose(SetBackOffAmount(1 * second), SetDirective(Directive.Restart), Redirect(MessageDirective.StayInQueue)) : SetDirective(Directive.Stop))
+                        : x.Global.Failures < 2
+                            ? Compose(SetBackOffAmount(1 * second), SetDirective(Directive.Resume), Redirect(MessageDirective.ForwardToSelf))
+                            : x.Global.Failures < 3
+                                ? Compose(SetBackOffAmount(1 * second), SetDirective(Directive.Restart), Redirect(MessageDirective.ForwardToSelf))
+                                : SetDirective(Directive.Stop)
+                    select y);
+
+                var answer = ask<string>(outer, "test");
+                Assert.Equal("TEST", answer); // make sure outer actor is running
+                tell(outer[nameof(DelayMissing)], "TEST");
+                    mre.WaitOne();
+                }
+
+                var expected = List(
+                    (0 * second, "setup 1"),
+                    (0 * second, "inbox 1"),
+                    (1 * second, "inbox 2"),
+                    (2 * second, "setup 2"),
+                    (3 * second, "setup 3"),
+                    (4 * second, "setup 4")
+                    );
+                Assert.Equal(expected.Map(_ => _.Item2), events.Map(_ => _.Item2));
+                foreach (var timing in expected.Zip(events.Map(_ => _.Item1)))
+                {
+                    Assert.True((timing.Item2 - timing.Item1.Item1).Abs() < 0.3 * seconds, $"Timing different: {timing.Item1.Item2} expected {timing.Item1.Item1}, but was {timing.Item2}");
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
There is a timing issue in current echo code regarding strategy handling. This PR should fix it.

I hope I can find time to add a small unit test example:

Anyway I'll try some explanation about problem and solution:

If actor inboxFn fails and strategy decision A is "Restart with Delay" then this happens (among other things):

A1. return InboxDirective.Pause (stopping the next message from getting to ProcessMessage).
A2. (delayed) DisposeState
A3. tellSystem(SystemMessage.StartupProcess)
A4. unpause()

Number 2 and 3 are named "Restart()".

If startup (initiated by A3) fails it might get another strategy decision B "Restart with delay". BUG: This delay is dropped due to wrong timing: A4 ("unpause" of the first strategy decision RunProcessDirective) can get in the way -- immediately reactivating the actor inbox . ProcessMessage then will re-create state implicitely (because already destroyed by B2) and so on.

After the second decisions' delay there will be another startup (B3), which is (in this case) either unneeded (state already re-build in ProcessMessage caused by A4) or unwanted (state still could not be rebuild, a third RunStrategy decision C is running around...). Again B4 (unpause of B) might get in the way.


To fix this I changed these things:

- StartUp+Unpause is an atomic SystemMessage (unpauseAfterRestart is a parameter of SystemMessage now)
- PausableBlockingQueue checks Startup() for a (new) return value. If this values says "Pause" then ignore the unpauseAfterRestart parameter (don't unpause) -- because Startup returning "Pause" (instead of Default) means: let inbox Paused because I ran into an error and strategy will handle this (including unpausing later).
