### PR TITLE
do not run messageHandler if actor is shut down

### DIFF
--- a/Echo.Process/ActorSys/ActorInboxLocal.cs
+++ b/Echo.Process/ActorSys/ActorInboxLocal.cs
@@ -40,7 +40,7 @@ namespace Echo
             sysInbox = new PausableBlockingQueue<SystemMessage>(this.maxMailboxSize);
 
             var obj = new ThreadObj { Actor = actor, Inbox = this, Parent = parent };
-            userInbox.ReceiveAsync(obj, (state, msg) => ActorInboxCommon.UserMessageInbox(state.Actor, state.Inbox, msg, state.Parent));
+            userInbox.ReceiveAsync(obj, (state, msg) => process.CancellationTokenSource.IsCancellationRequested ? InboxDirective.Shutdown : ActorInboxCommon.UserMessageInbox(state.Actor, state.Inbox, msg, state.Parent));
             sysInbox.ReceiveAsync(obj, (state, msg) => ActorInboxCommon.SystemMessageInbox(state.Actor, state.Inbox, msg, state.Parent));
 
             return unit;


### PR DESCRIPTION
I think there is some race condition when shutting down process system (compare next PR). Practically this means heartbeat messages might be in process after system has shutdown which results in `throw new ProcessConfigException("You must call one of the  ProcessConfig.initialiseXXX functions");`  due to context being invalid.

This change should be safe because the handler function will check for cancellationToken anyway, so this is a shortcut (just to avoid the exception).
