### PR TITLE
Supp session persistence

### DIFF
--- a/Echo.Process/Session/SessionManager.cs
+++ b/Echo.Process/Session/SessionManager.cs
@@ -85,11 +85,9 @@ namespace Echo.Session
         /// <param name="sessionId"></param>
         /// <returns></returns>
         public Option<SessionVector> GetSession(SessionId sessionId) =>
-            Sync.GetSession(sessionId).IfNone( () =>
-                Sync.GetSession(from c in cluster
-                                from to in c.GetHashField<int>(SessionKey(sessionId), TimeoutKey)
-                                select Sync.Start(sessionId, to))
-                    .IfNone(() => failwith<SessionVector>("Session doesn't exist")));
+            Sync.GetSession(sessionId) || Sync.GetSession(from c in cluster
+                                                          from to in c.GetHashField<int>(SessionKey(sessionId), TimeoutKey)
+                                                          select Sync.Start(sessionId, to));
 
         const string LastAccessKey = "__last-access";
         const string TimeoutKey = "__timeout";

--- a/Echo.Process/Session/SessionManager.cs
+++ b/Echo.Process/Session/SessionManager.cs
@@ -44,13 +44,20 @@ namespace Echo.Session
                 // Look for stranded sessions that haven't been removed properly.  This is done once only
                 // on startup because the systems should be shutting down sessions on their own.  This just
                 // catches the situation where an app-domain died without shutting down properly.
-                c.QuerySessionKeys()
-                 .Map(key =>
-                    from ts in c.GetHashField<long>(key, LastAccessKey)
-                    from to in c.GetHashField<int>(key, TimeoutKey)
-                    where new DateTime(ts) < now.AddSeconds(-to * 2) // Multiply by 2, just to catch genuine non-active sessions
-                    select c.Delete(key))
-                 .Iter(id => { });
+                var strandedSessions = c.QuerySessionKeys()
+                                        .Map(key =>
+                                                from ts in c.GetHashField<long>(key, LastAccessKey)
+                                                from to in c.GetHashField<int>(key, TimeoutKey)
+                                                where new DateTime(ts) < now.AddSeconds(-to * 2)   // Multiply by 2, just to catch genuine non-active sessions
+                                                select key).Somes().ToSeq();
+
+
+                strandedSessions.Iter(s => c.Delete(s));
+
+                c.GetHashFields(SupplementarySessionId.Key)
+                    .Where(sid => strandedSessions.Exists(k => k == SessionKey(sid as string)))
+                    .Iter(field => c.DeleteHashField(SupplementarySessionId.Key, field.Key));
+
 
                 // Remove session keys when an in-memory session ends
                 ended = SessionEnded.Subscribe(sid => Stop(sid));
@@ -91,10 +98,10 @@ namespace Echo.Session
 
         const string LastAccessKey = "__last-access";
         const string TimeoutKey = "__timeout";
-
-        private static string SessionKey(SessionId sessionId) =>
+        
+        static string SessionKey(SessionId sessionId) =>
             $"sys-session-{sessionId}";
-
+        
         public LanguageExt.Unit Start(SessionId sessionId, int timeoutSeconds)
         {
             Sync.Start(sessionId, timeoutSeconds);
@@ -106,6 +113,7 @@ namespace Echo.Session
         {
             Sync.Stop(sessionId);
             cluster.Iter(c => c.Delete(SessionKey(sessionId)));
+            deleteSuppSessionInClusterMap(sessionId);
             return cluster.Iter(c => c.PublishToChannel(SessionsNotify, SessionAction.Stop(sessionId, system, nodeName)));
         }
 
@@ -130,6 +138,11 @@ namespace Echo.Session
         {
             Sync.SetData(sessionId, key, value, time);
             cluster.Iter(c => c.HashFieldAddOrUpdate(SessionKey(sessionId), key, SessionDataItemDTO.Create(value)));
+
+            if(key == SupplementarySessionId.Key && value is SupplementarySessionId supp)
+            {
+                setSuppSessionInClusterMap(supp, sessionId);
+            }
              
             return cluster.Iter(c => c.PublishToChannel(SessionsNotify, SessionAction.SetData(
                 time,
@@ -143,6 +156,11 @@ namespace Echo.Session
 
         public LanguageExt.Unit ClearData(long time, SessionId sessionId, string key)
         {
+            if (key == SupplementarySessionId.Key)
+            {
+                deleteSuppSessionInClusterMap(sessionId);
+            }
+
             Sync.ClearData(sessionId, key, time);
             cluster.Iter(c => c.DeleteHashField(SessionKey(sessionId), key));
 
@@ -152,13 +170,31 @@ namespace Echo.Session
                     SessionAction.ClearData(time, sessionId, key, system, nodeName)));
         }
 
+        LanguageExt.Unit setSuppSessionInClusterMap(SupplementarySessionId suppSessionId, SessionId sessionId) =>
+            cluster.Iter(c => c.HashFieldAddOrUpdate(SupplementarySessionId.Key, suppSessionId.Value, sessionId.Value));
+
+        LanguageExt.Unit deleteSuppSessionInClusterMap(SessionId sessionId) =>
+            ignore(from c   in cluster.ToSeq()
+                   from key in c.GetHashFields(SupplementarySessionId.Key)
+                                .Where(o => (o as string) == sessionId.Value)
+                                .Map(v => v.Key).ToSeq()
+                   select c.DeleteHashField(SupplementarySessionId.Key, key));
+
+        Option<SessionId> getSessionIdFromSuppSessionClusterMap(SupplementarySessionId suppSessionId) =>
+            from c  in cluster
+            from s  in c.GetHashField<string>(SupplementarySessionId.Key, suppSessionId.Value).Map(v => new SessionId(v))
+            from to in c.GetHashField<int>(SessionKey(s), TimeoutKey)
+            let  _  =  Sync.UpdateSupplementarySessionId(suppSessionId, s)
+            select Sync.Start(s, to);
+
+
         /// <summary>
-        /// Attempts to get a SessionId by supplementary session ID.  Only checked locally.
+        /// Attempts to get a SessionId by supplementary session ID.  
         /// </summary>
         /// <param name="supplementarySessionId"></param>
         /// <returns></returns>
         public Option<SessionId> GetSessionId(SupplementarySessionId supplementarySessionId) => 
-            Sync.GetSessionId(supplementarySessionId);
+            Sync.GetSessionId(supplementarySessionId) || getSessionIdFromSuppSessionClusterMap(supplementarySessionId);
 
         /// <summary>
         /// Attempts to get a supplementary sessionId by session ID.  Only checked locally.

--- a/Echo.Process/Session/SessionSync.cs
+++ b/Echo.Process/Session/SessionSync.cs
@@ -194,7 +194,7 @@ namespace Echo.Session
         /// </summary>
         public LanguageExt.Unit SetData(SessionId sessionId, string key, object value, long vector)
         {
-            if(value is SupplementarySessionId supp)
+            if(key == SupplementarySessionId.Key && value is SupplementarySessionId supp)
             {
                 lock (sync)
                 {
@@ -211,16 +211,19 @@ namespace Echo.Session
         public LanguageExt.Unit ClearData(SessionId sessionId, string key, long vector) =>
             sessions.Find(sessionId).Iter(s =>
             {
-                s.GetExistingData(key).Iter(v =>
+                if (key == SupplementarySessionId.Key)
                 {
-                    if (v.Vector.Head is SupplementarySessionId sid)
+                    s.GetExistingData(key).Iter(v =>
                     {
-                        lock (sync)
+                        if (v.Vector.Head is SupplementarySessionId sid)
                         {
-                            suppSessions = suppSessions.Remove(sid);
+                            lock (sync)
+                            {
+                                suppSessions = suppSessions.Remove(sid);
+                            }
                         }
-                    }
-                });
+                    });
+                }
 
                 s.ClearKeyValue(vector, key);
             });

--- a/Echo.Process/Session/SessionSync.cs
+++ b/Echo.Process/Session/SessionSync.cs
@@ -119,6 +119,22 @@ namespace Echo.Session
             suppSessions.Find(sessionId);
 
         /// <summary>
+        /// Updates the suppSessionMap
+        /// </summary>
+        /// <param name="suppSessionId"></param>
+        /// <param name="sessionId"></param>
+        /// <returns></returns>
+        internal LanguageExt.Unit UpdateSupplementarySessionId(SupplementarySessionId suppSessionId, SessionId sessionId)
+        {
+            lock (sync)
+            {
+                suppSessions = suppSessions.AddOrUpdate(suppSessionId, sessionId);
+            }
+
+            return unit;
+        }
+
+        /// <summary>
         /// Start a new session
         /// </summary>
         public SessionId Start(SessionId sessionId, int timeoutSeconds)


### PR DESCRIPTION
a map from `supp-session-id` to `session-id` is now stored in cluster. This helps in retrieving `session-id` using `supp-session-id`.

Couple of other minor fixes too.