### PR TITLE
Session cleanup optimization

### DIFF
--- a/Echo.Process.Redis/RedisClusterImpl.cs
+++ b/Echo.Process.Redis/RedisClusterImpl.cs
@@ -209,7 +209,10 @@ namespace Echo
             Retry(() => Db.KeyDelete(key));
 
         public bool DeleteMany(params string[] keys) =>
-            Retry(() => Db.KeyDelete(keys.Map(k => (RedisKey)k).ToArray())==keys.Length);
+            DeleteMany(keys.AsEnumerable());
+
+        public bool DeleteMany(IEnumerable<string> keys) =>
+            Retry(() => Db.KeyDelete(keys.Map(k => (RedisKey)k).ToArray()) == keys.Count());
 
         public int QueueLength(string key) =>
             Retry(() => (int)Db.ListLength(key));

--- a/Echo.Process/Cluster/ICluster.cs
+++ b/Echo.Process/Cluster/ICluster.cs
@@ -177,5 +177,6 @@ namespace Echo
         Set<T> GetSet<T>(string key);
         bool SetContains<T>(string key, T value);
         bool SetExpire(string key, TimeSpan time);
+        Map<string, Map<string, object>> GetAllHashFieldsInBatch(Seq<string> keys);
     }
 }

--- a/Echo.Process/Cluster/ICluster.cs
+++ b/Echo.Process/Cluster/ICluster.cs
@@ -177,6 +177,6 @@ namespace Echo
         Set<T> GetSet<T>(string key);
         bool SetContains<T>(string key, T value);
         bool SetExpire(string key, TimeSpan time);
-        Map<string, Map<string, object>> GetAllHashFieldsInBatch(Seq<string> keys);
+        Task<Map<string, Map<string, object>>> GetAllHashFieldsInBatch(Seq<string> keys);
     }
 }

--- a/Echo.Process/Cluster/ICluster.cs
+++ b/Echo.Process/Cluster/ICluster.cs
@@ -110,6 +110,12 @@ namespace Echo
         bool DeleteMany(params string[] keys);
 
         /// <summary>
+        /// Remove many keys
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        bool DeleteMany(IEnumerable<string> keys);
+
+        /// <summary>
         /// Look at the item at the head of the queue
         /// </summary>
         T Peek<T>(string key);

--- a/Echo.Process/Session/SessionManager.cs
+++ b/Echo.Process/Session/SessionManager.cs
@@ -53,7 +53,8 @@ namespace Echo.Session
                                     .Keys)
                     .Map(Seq)
                     .Do(strandedSessions  => SupplementarySessionManager.removeSessionIdFromSuppMap(c, strandedSessions.Map(ReverseSessionKey)))
-                    .Map(strandedSessions => c.DeleteMany(strandedSessions));
+                    .Do(strandedSessions  => c.DeleteMany(strandedSessions))
+                    .Map(strandedSessions => strandedSessions.Iter(sessionId => c.PublishToChannel(SessionsNotify, SessionAction.Stop(sessionId, system, nodeName)))); ;
                     
 
 

--- a/Echo.Process/Session/SessionManager.cs
+++ b/Echo.Process/Session/SessionManager.cs
@@ -62,8 +62,12 @@ namespace Echo.Session
                 {
                     try
                     {
-                        c.HashFieldAddOrUpdate(SessionKey(tup.Item1), LastAccessKey, DateTime.UtcNow.Ticks);
-                        c.PublishToChannel(SessionsNotify, SessionAction.Touch(tup.Item1, system, nodeName));
+                        //check if the session has not been stopped in the meantime or expired
+                        if (c.Exists(SessionKey(tup.Item1)))
+                        {
+                            c.HashFieldAddOrUpdate(SessionKey(tup.Item1), LastAccessKey, DateTime.UtcNow.Ticks);
+                            c.PublishToChannel(SessionsNotify, SessionAction.Touch(tup.Item1, system, nodeName));
+                        }
                     }
                     catch(Exception e)
                     {

--- a/Echo.Process/Session/SessionManager.cs
+++ b/Echo.Process/Session/SessionManager.cs
@@ -208,8 +208,8 @@ namespace Echo.Session
 
     static class SupplementarySessionManager
     {
-        const string sessionToSuppKey = "sys-session-supp";
-        const string suppToSessionKey = "sys-supp-session";
+        const string sessionToSuppKey = "sys-map-session-supp";
+        const string suppToSessionKey = "sys-map-supp-session";
 
         internal static LanguageExt.Unit setSuppSessionInSuppMap(this ICluster cluster, SessionId sessionId, SupplementarySessionId suppSessionId)
         {


### PR DESCRIPTION
a few optimizations + changed the way stranded sessions are retrieved. Instead of iterating over keys and retrieving hash values multiple times, all hashvalues are retrieved using batch command. 

For roughly 500,000 redis keys in local db, 

In Iteration
55.0507909 seconds 
In transaction
10.5097816 seconds
In Batch
8.6244505 seconds

Also,

- the deletion of keys happen in bulk now,
- changed the name of map in redis to avoid conflict with session key pattern
