### PR TITLE
LocalScheduler does not work

### DIFF
--- a/Echo.Process/ActorSys/LocalScheduler.cs
+++ b/Echo.Process/ActorSys/LocalScheduler.cs
@@ -12,7 +12,8 @@ namespace Echo
     internal static class LocalScheduler
     {
         static object sync = new object();
-        static HashMap<long, Seq<(string key, Func<object, Unit> action, object message, ActorRequestContext context, Option<SessionId> sessionId)>> actions;
+        // using Map for 'actions' as we rely on order
+        static Map<long, Seq<(string key, Func<object, Unit> action, object message, ActorRequestContext context, Option<SessionId> sessionId)>> actions;
         static HashMap<string, long> keys;
         static Que<(Schedule schedule, ProcessId pid, Func<object, Unit> action, object message, ActorRequestContext context, Option<SessionId> sessionId)> inbound;
 


### PR DESCRIPTION
This change https://github.com/louthy/echo-process/commit/971fde0c02ff2527bc401e2ed74b7d093599dcbf  broke the LocalScheduler as we rely on ordering (line 161). Changed back to `Map`.