### PR TITLE
suppress running delayed error handling after shutdown

### DIFF
--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -876,10 +876,13 @@ namespace Echo
                         if (decision.ProcessDirective.Type != DirectiveType.Stop && decision.Pause > 0 * seconds)
                         {
                             decision.Affects.Iter(p => pause(p));
-                            safedelay(
+
+                            var safeDelayDisposable = safedelay(
                                 () => RunProcessDirective(pid, sender, ex, message, decision, true),
                                 decision.Pause
                             );
+                            cancellationTokenSource.Token.Register(() => safeDelayDisposable.Dispose());
+
                             return InboxDirective.Pause | RunMessageDirective(pid, sender, decision, ex, message);
                         }
                         else

--- a/Echo.Process/Exceptions.cs
+++ b/Echo.Process/Exceptions.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -351,4 +352,18 @@ namespace Echo
         }
     }
     
+    public class ProcessSystemException : Exception
+    {
+        public override string StackTrace { get; }
+
+        internal ProcessSystemException(Exception ex, StackTrace stackTrace) : base(ex.Message, ex)
+        {
+            StackTrace = stackTrace.ToString();
+        }
+
+        public override string Message => $"{InnerException?.GetType().Name} {InnerException?.Message}";
+
+        public override string ToString() =>
+            $"{nameof(ProcessSystemException)}: {Message}{Environment.NewLine} ---> {InnerException}{Environment.NewLine}   --- End of inner exception ---{Environment.NewLine}{StackTrace}";
+    }
 }

--- a/Echo.Process/Prelude_Internal.cs
+++ b/Echo.Process/Prelude_Internal.cs
@@ -55,6 +55,7 @@ namespace Echo
         {
             var savedContext = ActorContext.Request;
             var savedSession = ActorContext.SessionId;
+            var stackTrace   = new System.Diagnostics.StackTrace(true);
 
             return Observable.Timer(delayFor).Do(_ =>
             {
@@ -64,7 +65,18 @@ namespace Echo
                 }
                 else
                 {
-                    ActorContext.System(savedContext.Self.Actor.Id).WithContext(
+                    ActorSystem system;
+                    try
+                    {
+
+                        system = ActorContext.System(savedContext.Self.Actor.Id);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new ProcessSystemException(e, stackTrace);
+                    }
+
+                    system.WithContext(
                                   savedContext.Self,
                                   savedContext.Parent,
                                   savedContext.Sender,

--- a/Echo.Process/Prelude_Internal.cs
+++ b/Echo.Process/Prelude_Internal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using static LanguageExt.Prelude;
 using LanguageExt;
@@ -55,39 +56,31 @@ namespace Echo
             var savedContext = ActorContext.Request;
             var savedSession = ActorContext.SessionId;
 
-            return (IDisposable)Task.Delay(delayFor).ContinueWith(_ =>
-              {
-                  try
-                  {
-                      if (savedContext == null)
-                      {
-                          f();
-                      }
-                      else
-                      {
-                          ActorContext.System(savedContext.Self.Actor.Id).WithContext(
-                                       savedContext.Self,
-                                       savedContext.Parent,
-                                       savedContext.Sender,
-                                       savedContext.CurrentRequest,
-                                       savedContext.CurrentMsg,
-                                       savedSession,
-                                       () =>
-                                       {
-                                           f();
+            return Observable.Timer(delayFor).Do(_ =>
+            {
+                if (savedContext == null)
+                {
+                    f();
+                }
+                else
+                {
+                    ActorContext.System(savedContext.Self.Actor.Id).WithContext(
+                                  savedContext.Self,
+                                  savedContext.Parent,
+                                  savedContext.Sender,
+                                  savedContext.CurrentRequest,
+                                  savedContext.CurrentMsg,
+                                  savedSession,
+                                  () =>
+                                  {
+                                      f();
 
-                                           // Run the operations that affect the settings and sending of tells
-                                           // in the order which they occured in the actor
-                                           ActorContext.Request?.Ops?.Run();
-                                       });
-                      }
-
-                  }
-                  catch (Exception e)
-                  {
-                      logErr(e);
-                  }
-              });
+                                      // Run the operations that affect the settings and sending of tells
+                                      // in the order which they occured in the actor
+                                      ActorContext.Request?.Ops?.Run();
+                                  });
+                }
+            }).Subscribe(onNext: _ => { }, onCompleted: () => { }, onError: logErr);
         }
 
         internal static IDisposable safedelay(Action f, DateTime delayUntil) =>


### PR DESCRIPTION
I had error messages like #55 for some time now and think I have found one major cause.

I use a strategy with some backoff time which means the actor internally will call safedelay to reactive processing after some time. When the actor shuts down in the meantime this will result in the error message because safedelay accesses a ref to ActorSystem which is null then.

The [first commit b27c62c](https://github.com/louthy/echo-process/commit/b27c62cef1400fdc90f50cd793ea55cc683e3e70) should solve the problem. 

The [second commit 445c63a](https://github.com/louthy/echo-process/commit/445c63a8ae7069a8cc2aa4cbc488648b7318e615) is optional. I added this stacktrace-saving exception to identify the issue. Maybe it's still useful as debugging help for this or similar operations.

**Note:** I had no time to test this minified patch yet -- I just rebased/refactored it to make the change smaller and on top of current master...  I will integrate this version next week and give feedback.
