### PR TITLE
StrategyState.FirstFailure (feature)

### DIFF
--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -627,6 +627,7 @@ namespace Echo
 
                     strategyState = strategyState.With(
                         Failures: 0,
+                        FirstFailure: DateTime.MaxValue,
                         LastFailure: DateTime.MaxValue,
                         BackoffAmount: 0 * seconds
                     );
@@ -706,6 +707,7 @@ namespace Echo
 
                     strategyState = strategyState.With(
                         Failures: 0,
+                        FirstFailure: DateTime.MaxValue,
                         LastFailure: DateTime.MaxValue,
                         BackoffAmount: 0 * seconds
                         );
@@ -822,6 +824,7 @@ namespace Echo
 
                     strategyState = strategyState.With(
                         Failures: 0,
+                        FirstFailure: DateTime.MaxValue,
                         LastFailure: DateTime.MaxValue,
                         BackoffAmount: 0 * seconds
                         );

--- a/Echo.Process/Strategy/Strategy.cs
+++ b/Echo.Process/Strategy/Strategy.cs
@@ -77,6 +77,16 @@ namespace Echo
             select y;
 
         /// <summary>
+        /// Sets the first-failure state.  
+        /// </summary>
+        /// <param name="when">Time to set</param>
+        /// <returns>Strategy computation as a State monad</returns>
+        public static State<StrategyContext, Unit> SetFirstFailure(DateTime when) =>
+            from x in Context
+            from y in put(x.With(Global: x.Global.With(FirstFailure: when)))
+            select y;
+
+        /// <summary>
         /// Sets the last-failure state.  
         /// </summary>
         /// <param name="when">Time to set</param>
@@ -227,16 +237,16 @@ namespace Echo
             MapGlobal(g => g.With(Failures: g.Failures + 1));
 
         /// <summary>
-        /// Reset the failure count state to zero and set LastFailure to max-value
+        /// Reset the failure count state to zero and set FirstFailure and LastFailure to max-value
         /// </summary>
         public static readonly State<StrategyContext, Unit> ResetFailureCount =
-            MapGlobal(g => g.With(Failures: 0, LastFailure: DateTime.MaxValue));
+            MapGlobal(g => g.With(Failures: 0, FirstFailure: DateTime.MaxValue, LastFailure: DateTime.MaxValue));
 
         /// <summary>
-        /// Set the failure count to 1 and set LastFailure to UtcNow
+        /// Set the failure count to 1 and set FirstFailure and LastFailure to UtcNow
         /// </summary>
         public static readonly State<StrategyContext, Unit> FailedOnce =
-            MapGlobal(g => g.With(Failures: 1, LastFailure: DateTime.UtcNow));
+            MapGlobal(g => g.With(Failures: 1, FirstFailure: DateTime.UtcNow, LastFailure: DateTime.UtcNow));
 
         /// <summary>
         /// Always return this Directive in the final StrategyDecision

--- a/Echo.Process/Strategy/StrategyEvent.cs
+++ b/Echo.Process/Strategy/StrategyEvent.cs
@@ -52,7 +52,7 @@ namespace Echo
                         state.Pause
                     );
 
-                    return (decision, state.Global.With(LastFailure: now));
+                    return (decision, state.Global.With(FirstFailure: stateInst.FirstFailure == DateTime.MaxValue ? DateTime.UtcNow : stateInst.FirstFailure, LastFailure: now));
                 });
     }
 }

--- a/Echo.Process/Strategy/StrategyState.cs
+++ b/Echo.Process/Strategy/StrategyState.cs
@@ -13,20 +13,23 @@ namespace Echo
     {
         public readonly Time BackoffAmount;
         public readonly int Failures;
+        public readonly DateTime FirstFailure;
         public readonly DateTime LastFailure;
         public readonly HashMap<string, object> Metadata;
 
-        public static readonly StrategyState Empty = new StrategyState(0 * seconds, 0, DateTime.MaxValue, HashMap<string, object>());
+        public static readonly StrategyState Empty = new StrategyState(0 * seconds, 0, DateTime.MaxValue, DateTime.MaxValue, HashMap<string, object>());
 
         public StrategyState(
             Time backoffAmount,
             int failures,
+            DateTime firstFailure,
             DateTime lastFailure,
             HashMap<string, object> metadata
             )
         {
             BackoffAmount = backoffAmount;
             Failures = failures;
+            FirstFailure = firstFailure;
             LastFailure = lastFailure;
             Metadata = metadata;
         }
@@ -69,12 +72,14 @@ namespace Echo
         public StrategyState With(
             Time? BackoffAmount = null,
             int? Failures = null,
+            DateTime? FirstFailure = null,
             DateTime? LastFailure = null,
             HashMap<string, object>? Metadata = null
             ) =>
             new StrategyState(
                 BackoffAmount ?? this.BackoffAmount,
                 Failures ?? this.Failures,
+                FirstFailure ?? this.FirstFailure,
                 LastFailure ?? this.LastFailure,
                 Metadata ?? this.Metadata
             );

--- a/Echo.Process/Strategy/StrategyState.cs
+++ b/Echo.Process/Strategy/StrategyState.cs
@@ -51,7 +51,7 @@ namespace Echo
             With(Metadata: Metadata.TryAdd(key, value));
 
         /// <summary>
-        /// Attempts to set a meta-data item.  If it is already set, nothing 
+        /// Attempts to remove a meta-data item.  If it is not set, nothing 
         /// happens.
         /// 
         /// This is for extending the default strategies behaviours and 


### PR DESCRIPTION
Adds FirstFailure to StrategyState.

Same logic as LastFailure, only difference is that FirstFailure doesn't get updated on subsequent failures (so one can calculation the duration of the error state until now).

Initialized with DateTime.MaxValue (as LastFailure).
