### PR TITLE
Opening doors to change Newtonsoft.Json configuration

### DIFF
--- a/Echo.Process/ActorSys/ActorSystemConfig.cs
+++ b/Echo.Process/ActorSys/ActorSystemConfig.cs
@@ -22,12 +22,7 @@ namespace Echo
         public readonly ProcessName SchedulerName                = "scheduler";
 
         public readonly JsonSerializerSettings JsonSerializerSettings =
-            new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All,
-                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
-                MissingMemberHandling = MissingMemberHandling.Ignore
-            };
+            JsonSerializer.Settings;
 
         public readonly static ActorSystemConfig Default =
             new ActorSystemConfig();

--- a/Echo.Process/Messages/JsonSerializer.cs
+++ b/Echo.Process/Messages/JsonSerializer.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+
+namespace Echo
+{
+    /// <summary>
+    /// A configuration for a message serializer.
+    /// </summary>
+    /// <remarks>You need to set Settings before you start the echo processes system.</remarks>
+    public static class JsonSerializer
+    {
+        /// <summary>
+        /// Set echo internal setup of the serializer the client does not need to be aware of.
+        /// </summary>
+        static JsonSerializerSettings Setup(JsonSerializerSettings settings)
+        {
+            settings.TypeNameHandling = TypeNameHandling.All;
+            settings.TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
+            settings.MissingMemberHandling = MissingMemberHandling.Ignore;
+            return settings;
+        }
+
+        static JsonSerializerSettings settings = Setup(new JsonSerializerSettings());
+        
+        public static JsonSerializerSettings Settings
+        {
+            get => settings;
+            set => settings = Setup(value ?? new JsonSerializerSettings());
+        }
+    }
+}


### PR DESCRIPTION
Added `JsonSerializer` class that could be used to access `JsonSerializerSettings`. This is needed to add custom convertors (e.g. for `NodaTime`) but also custom bindings etc. The internal `Setup` func makes sure the echo-specific configuration is set properly.