### PR TITLE
Fix NRE in Actor.ProcessMessage when interacting with traceInbox and …

### DIFF
--- a/Echo.Process/ActorSys/Actor.cs
+++ b/Echo.Process/ActorSys/Actor.cs
@@ -796,19 +796,12 @@ namespace Echo
             var savedFlags = ActorContext.Request.ProcessFlags;
             var savedMsg   = ActorContext.Request.CurrentMsg;
 
-            var spanBuilder = traceInbox?.WithTag("type", "tell");
-            if (message is not null)
-            {
-                spanBuilder = spanBuilder
-                    .WithTag("message-type", message?.GetType().FullName);
-            }
-            if (savedReq is not null)
-            {
-                spanBuilder = spanBuilder
-                    .WithTag("conversation-id", savedReq?.ConversationId.ToString() ?? "")
-                    .WithTag("reply-to", savedReq?.ReplyTo.ToString() ?? "");
-            }
-            var span = spanBuilder.StartActive();
+            var span = traceInbox?.WithTag("type", "tell")
+                                  .WithTag("message-type", message?.GetType().FullName)
+                                  .WithTag("conversation-id", savedReq?.ConversationId ?? 0)
+                                  .WithTag("request-id", savedReq?.RequestId ?? 0)
+                                  .WithTag("reply-to", savedReq?.ReplyTo.ToString() ?? "")
+                                  .StartActive();
 
             try
             {


### PR DESCRIPTION
…there is no savedReq reference (instead of writing empty tags in this case, I thought it was better to write no tag at all if that data is not available)